### PR TITLE
Added created project editor

### DIFF
--- a/src/gigs-board/pages/community/projects.jsx
+++ b/src/gigs-board/pages/community/projects.jsx
@@ -208,6 +208,16 @@ const project_mock = {
   },
 };
 
+initState({
+  createProject: false,
+  isEditorActive: true,
+});
+
+function createProject({ tag, name, description }) {
+  if (tag && name && description)
+    DevHub.create_project({ tag, name, description });
+}
+
 const CommunityProjectsPage = ({ handle }) => {
   const community = DevHub.useQuery({ name: "community", params: { handle } });
 
@@ -236,9 +246,64 @@ const CommunityProjectsPage = ({ handle }) => {
                     adornment: "bi bi-tools",
                   },
                   label: "Create project",
-                  onClick: () => {},
+                  onClick: () => {
+                    State.update({
+                      createProject: !state.createProject,
+                    });
+                  },
                 })
               : null}
+          </div>
+          <div className="d-flex align-items-center justify-content-center">
+            {state.createProject &&
+              widget("components.organism.editor", {
+                classNames: {
+                  submit: "btn-primary",
+                  submitAdornment: "bi-check-circle-fill",
+                },
+
+                heading: "Create project",
+                isEditorActive: state.isEditorActive,
+                isEditingAllowed: Viewer.can.editCommunity,
+                onCancel: () => State.update({ createProject: false }),
+                onChangesSubmit: createProject,
+                submitLabel: "Accept",
+                data: state.teamData,
+                schema: {
+                  name: {
+                    inputProps: {
+                      min: 2,
+                      max: 60,
+                      placeholder: "Project name",
+                      required: true,
+                    },
+
+                    label: "Name",
+                    order: 1,
+                  },
+                  description: {
+                    label: "Description",
+                    order: 2,
+                    inputProps: {
+                      min: 2,
+                      max: 60,
+                      placeholder:
+                        "Describe your project in one short sentence that will appear below the tile of the project on this page.",
+                      required: true,
+                    },
+                  },
+                  tag: {
+                    inputProps: {
+                      min: 2,
+                      max: 30,
+                      placeholder: "tag",
+                      required: true,
+                    },
+                    label: "Tag",
+                    order: 3,
+                  },
+                },
+              })}
           </div>
 
           {community_projects_metadata.data === null ? (

--- a/src/gigs-board/pages/community/projects.jsx
+++ b/src/gigs-board/pages/community/projects.jsx
@@ -288,7 +288,7 @@ const CommunityProjectsPage = ({ handle }) => {
                       min: 2,
                       max: 60,
                       placeholder:
-                        "Describe your project in one short sentence that will appear below the tile of the project on this page.",
+                        "Describe your project in one short sentence.",
                       required: true,
                     },
                   },

--- a/src/gigs-board/pages/community/projects.jsx
+++ b/src/gigs-board/pages/community/projects.jsx
@@ -273,7 +273,7 @@ const CommunityProjectsPage = ({ handle }) => {
                   name: {
                     inputProps: {
                       min: 2,
-                      max: 60,
+                      max: 30,
                       placeholder: "Project name",
                       required: true,
                     },


### PR DESCRIPTION
Hi Carina!

Concerning [#223](https://github.com/near/neardevhub-widgets/issues/223)

I added this editor the projects page inside the community page. It's quiet simple since I reused your edit community editor. Would you like me to add more details? If so how can I assist?

<img width="1385" alt="Screenshot 2023-08-03 at 13 58 31" src="https://github.com/carina-akaia/neardevhub-widgets/assets/28901891/1115fc01-161e-4518-84fa-a800ac5fb5e0">
